### PR TITLE
Add a dockerfile responsible for an RDP windows solution

### DIFF
--- a/environments/build/Dockerfile
+++ b/environments/build/Dockerfile
@@ -1,0 +1,8 @@
+# FROM frxyt/xrdp:lxde
+FROM frxyt/xrdp@sha256:a6ca8cfbacd3898cd9f2008ad47936a01929b64ba93962092232b31be805f2ec
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
+    && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+
+RUN apt-get update && apt-get install -y bazel make g++ pkg-config libx11-dev mesa-common-dev libglu1-mesa-dev libxrandr-dev libxi-dev

--- a/environments/build/README.md
+++ b/environments/build/README.md
@@ -1,0 +1,10 @@
+# Build Environment for Windows
+
+The build environment can be built from the repository root with the following command:
+
+```bash
+docker build --file environments/build/Dockerfile --tag ubuntu-xrdp environments/build/.
+docker run --rm --name=xplatformer -d -v "//${PWD}":/workspace -e FRX_XRDP_USER_NAME=jrbeverly -p 33890:3389 ubuntu-xrdp
+```
+
+The environment can then be logged into with the credentials `jrbeverly:ChangeMe`.

--- a/environments/build/run.bash
+++ b/environments/build/run.bash
@@ -1,0 +1,5 @@
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+docker build --file "${DIR}/Dockerfile" --tag ubuntu-xrdp "${DIR}/."
+docker run --rm --name=xplatformer -d -v "//${PWD}":/workspace -e FRX_XRDP_USER_NAME=jrbeverly -p 33890:3389 ubuntu-xrdp


### PR DESCRIPTION
A linux container with xrdp installed to allow building the game in a linux environment, while also being able to interact with the game on a screen. Rather than require linux, using a docker environment makes it more portable.

The VNC solution was having significant keyboard delay when performing actions. This made it difficult to diagnose some of the errors I was seeing with movement and collision. 