### PR TITLE
Initial commit of the bazel workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,11 @@
+new_local_repository(
+    name = "system_libs",
+    build_file_content = """
+cc_library(
+    name = "x11",
+    srcs = ["libX11.so"],
+    visibility = ["//visibility:public"],
+)
+""",
+    path = "/usr/lib/x86_64-linux-gnu",
+)


### PR DESCRIPTION
Commit the workspace file that will be used for compiling the C++ XPlatformer project. Files responsible for compilation targets will follow after I have verified all dependencies are in.

This adds the dependency that any build environment will need to have X11 installed.