### PR TITLE
Ignore the bazel directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,8 @@ $RECYCLE.BIN/
 *.msm
 *.msp
 *.suo
-src/XPlatformer
 .vscode/
+
+# Ignore all bazel-* symlinks. There is no full list since this can change
+# based on the name of the directory bazel is cloned into.
+/bazel-*


### PR DESCRIPTION
Ignore the bazel directories that are created to hold build artifacts.